### PR TITLE
Console: Take Primary key handling elsewhere

### DIFF
--- a/console.py
+++ b/console.py
@@ -141,9 +141,6 @@ class HBNBCommand(cmd.Cmd):
             if kwargs == {}:
                 obj = eval(my_list[0])()
             else:
-                if os.getenv('HBNB_TYPE_STORAGE') == 'db':
-                    if not hasattr(kwargs, 'id'):
-                        kwargs['id'] = str(uuid.uuid4())
                 obj = HBNBCommand.classes[my_list[0]](**kwargs)
             obj.save()
             print(obj.id)

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -11,19 +11,21 @@ Base = declarative_base()
 
 
 class BaseModel:
+    """A base class for all hbnb models"""
+    
     id = Column(String(60), primary_key=True, nullable=False)
     format_str = '%Y-%m-%d %H:%M:%S.%f'
     created_at = Column(DateTime, nullable=False, default=(datetime.now()))
     updated_at = Column(DateTime, nullable=False, default=(datetime.now()))
-    """A base class for all hbnb models"""
+
     def __init__(self, *args, **kwargs):
-        id = Column(String(60), primary_key=True, nullable=False)
         """Instatntiates a new model"""
         if not kwargs:
-            from models import storage
-            self.id = str(uuid.uuid4())
-            self.created_at = datetime.now()
-            self.updated_at = datetime.now()
+            if (getenv('HBNB_TYPE_STORAGE') == 'file'):
+                self.id = str(uuid.uuid4())
+                self.created_at = datetime.now()
+                self.updated_at = datetime.now()
+
             
         else:
             for key, value in kwargs.items():
@@ -42,6 +44,9 @@ class BaseModel:
         """Updates updated_at with current time when instance is changed"""
         from models import storage
         self.updated_at = datetime.now()
+        if (getenv('HBNB_TYPE_STORAGE') == 'db'):
+            self.id = str(uuid.uuid4())
+        
         storage.new(self)
         models.storage.save()
 

--- a/models/user.py
+++ b/models/user.py
@@ -12,8 +12,8 @@ class User(BaseModel, Base):
         __tablename__ = 'users'
         email = Column(String(128), nullable=False)
         password = Column(String(128), nullable=False)
-        first_name = Column(String(128), nullable=False)
-        last_name = Column(String(128), nullable=False)
+        first_name = Column(String(128), nullable=True)
+        last_name = Column(String(128), nullable=True)
         reviews = relationship("Review", backref="user", cascade="delete")
         places = relationship("Place", backref="user", cascade="delete")
     else:


### PR DESCRIPTION
Users: first_name and last_name should be optional BaseModel: Make sure object is not sent for commit without proper Primary key
       This was handled by the create method in the console. But the issue arises when Object is created with external script